### PR TITLE
Guard default mapping by a variable

### DIFF
--- a/doc/firvish.txt
+++ b/doc/firvish.txt
@@ -227,6 +227,9 @@ Global ~
     <Plug>(firvish_history)
     <leader>h   Opens the history buffer. Same as |:History|
 
+    Note: the leader mappings are available only if you set
+    g:firvish_use_default_mappings to a non 0 value.
+
 Buffer-local (filetype=firvish-buffers) ~
     <enter>     Jumps to the buffer under the cursor. If the buffer is visible
                 in any window, swtiches to that one. Otherwise opens it in the

--- a/plugin/firvish.lua
+++ b/plugin/firvish.lua
@@ -10,11 +10,13 @@ local opt = vim.opt
 
 require"firvish.settings".init()
 
-map("n", "<leader>b", ":lua require'firvish.buffers'.open_buffers()<CR>",
-    {silent = true, nowait = true})
+if vim.g.firvish_use_default_mappings ~= nil and vim.g.firvish_use_default_mappings ~= 0 then
+    map("n", "<leader>b", ":lua require'firvish.buffers'.open_buffers()<CR>",
+        {silent = true, nowait = true})
 
-map("n", "<leader>h", ":lua require'firvish.history'.open_history()<CR>",
-    {silent = true, nowait = true})
+    map("n", "<leader>h", ":lua require'firvish.history'.open_history()<CR>",
+        {silent = true, nowait = true})
+end
 
 cmd [[command! Buffers lua require'firvish.buffers'.open_buffers()<CR>]]
 cmd [[command! History lua require'firvish.history'.open_history()<CR>]]


### PR DESCRIPTION
The default mappings (`<leader>b` and `<leader>h`) will be only applied
if `g:firvish_use_default_mappings != 0`. They may conflict with already
existing mappings and should be opt-in functionality.

If there is a better way to do that test in lua, please let me know. My lua is in it's infancies.