### PR TITLE
feat: start_job accepts custom on_exit

### DIFF
--- a/lua/firvish/job_control.lua
+++ b/lua/firvish/job_control.lua
@@ -349,10 +349,16 @@ M.start_job = function(opts)
         utils.set_qflist({}, " ", nil, {}, true)
     end
 
+    if opts.on_exit then
+        opts.on_exit = utils.wrap(opts.on_exit, on_exit)
+    else
+        opts.on_exit = on_exit
+    end
+
     local job_id = fn.jobstart(opts.cmd, {
         on_stderr = on_stderr,
         on_stdout = on_stdout,
-        on_exit = on_exit,
+        on_exit = opts.on_exit,
         stderr_buffered = false,
         stdout_buffered = false,
         cwd = opts.cwd,

--- a/lua/firvish/utils.lua
+++ b/lua/firvish/utils.lua
@@ -149,4 +149,11 @@ function table.extend(source, target)
     return source
 end
 
+function M.wrap(f0, f1)
+    return function(...)
+        f0(...)
+        f1(...)
+    end
+end
+
 return M


### PR DESCRIPTION
Useful to, e.g., create a symlink to compile_commands.json after
generating a buildsystem with cmake.
